### PR TITLE
Changed the project name to correct plugin convention 

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.artifact.apim.compositeapi/.project
+++ b/plugins/org.wso2.developerstudio.eclipse.artifact.apim.compositeapi/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.wso2.developerstudio.eclipse.artifact</name>
+	<name>org.wso2.developerstudio.eclipse.artifact.apim.compositeapi</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
This plugin initially created using the "WSO2 plugin project" type.
It only allows to insert plugin ID, therefore the project name always kept as "org.wso2.developerstudio.eclipse.artifact" despite the change of project name.
As this can be confusing for plugin developers, modified .project file with plugin ID.